### PR TITLE
Emergency Fix: Change PFX loading behaviour

### DIFF
--- a/scbalancer.js
+++ b/scbalancer.js
@@ -59,6 +59,7 @@ var SCBalancer = function (options) {
   this._proxy.on('error', this._handleError.bind(this));
 
   if (this.protocol == 'https') {
+    if(this.protocolOptions.pfx) this.protocolOptions.pfx = require('fs').readFileSync(this.protocolOptions.pfx);
     this._server = https.createServer(this.protocolOptions, this._handleRequest.bind(this));
   } else {
     this._server = http.createServer(this._handleRequest.bind(this));


### PR DESCRIPTION
I have received a multitude of errors while trying to use the protocolOptions object.
The PFX buffer does not seem to work (converted to a string or not) when putting it in protocolOptions.

So I changed the behaviour to load a file path instead. But I assume you guys will be able to figure out what causes these bugs.

PS: The passphrase seems to be required by SocketCluster, but not by the HTTPS module.
